### PR TITLE
Integration Testing for Categories

### DIFF
--- a/rareapi/views/categories.py
+++ b/rareapi/views/categories.py
@@ -53,15 +53,33 @@ class CategoryViewSet(viewsets.ViewSet):
     def update(self, request, pk=None):
         try:
             category = Category.objects.get(pk=pk)
-            serializer = CategorySerializer(data=request.data)
+            serializer = CategorySerializer(category, data=request.data)
             if serializer.is_valid():
                 category.label = serializer.validated_data['label']
                 category.save()
-                
-                serializer = CategorySerializer(Category, context={'request': request})
-                return Response(None, status.HTTP_204_NO_CONTENT)
+
+                # Use the serializer to serialize the updated category
+                updated_serializer = CategorySerializer(category, context={'request': request})
+                return Response(updated_serializer.data, status.HTTP_200_OK)
 
             return Response(serializer.errors, status.HTTP_400_BAD_REQUEST)
 
         except Category.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+
+    # def update(self, request, pk=None):
+    #     try:
+    #         category = Category.objects.get(pk=pk)
+    #         serializer = CategorySerializer(data=request.data)
+    #         if serializer.is_valid():
+    #             category.label = serializer.validated_data['label']
+    #             category.save()
+                
+    #             serializer = CategorySerializer(Category, context={'request': request})
+    #             return Response(None, status.HTTP_204_NO_CONTENT)
+
+    #         return Response(serializer.errors, status.HTTP_400_BAD_REQUEST)
+
+    #     except Category.DoesNotExist:
+    #         return Response(status=status.HTTP_404_NOT_FOUND)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 from .tag_tests import TagTests
+from .category_tests import CategoryTests

--- a/tests/category_tests.py
+++ b/tests/category_tests.py
@@ -1,0 +1,97 @@
+import json
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+from rareapi.models import Category
+from django.contrib.auth.models import User
+
+class CategoryTests(APITestCase):
+
+    fixtures = ['user', 'token', 'categories']
+
+    def setUp(self):
+        self.user = User.objects.first()
+        token = Token.objects.get(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+        
+    def test_create_cat(self):
+
+        url = "/categories"
+        data = {
+            "label": "Test Category"
+        }
+
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(json_response["label"], "Test Category")
+
+    def test_get_cat(self):
+
+        cat = Category()
+        cat.label = "Test Category"
+        cat.save()
+
+        # Initiate request and store response
+        response = self.client.get(f"/categories/{cat.id}")
+
+        # Parse the JSON in the response body
+        json_response = json.loads(response.content)
+
+        # Assert that the game was retrieved
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Assert that the values are correct
+        self.assertEqual(json_response["label"], "Test Category")
+        
+    def test_list_categories(self):
+
+        response = self.client.get('/categories')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(json_response[0]["label"], "News")
+        self.assertEqual(json_response[1]["label"], "Science")
+        self.assertEqual(json_response[2]["label"], "Technology")
+
+    def test_delete_cat(self):
+        """
+        Ensure we can delete an existing game.
+        """
+        cat = Category()
+        cat.label = "Test Category"
+        cat.save()
+
+        # DELETE the game you just created
+        response = self.client.delete(f"/categories/{cat.id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # GET the game again to verify you get a 404 response
+        response = self.client.get(f"/categories/{cat.id}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_change_cat(self):
+        """
+        Ensure we can change an existing category.
+        """
+        cat = Category()
+        cat.label = "Test Category"
+        cat.save()
+
+        # DEFINE NEW PROPERTIES FOR GAME
+        data = {
+            "label": "New Test Category"
+        }
+
+        response = self.client.put(f"/categories/{cat.id}", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # GET game again to verify changes were made
+        response = self.client.get(f"/categories/{cat.id}")
+        json_response = json.loads(response.content)
+
+        # Assert that the properties are correct
+       
+        self.assertEqual(json_response["label"], "New Test Category")
+       


### PR DESCRIPTION
## Overview:

- Added API integration tests for list, retrieve, create, destroy, and update methods on Categories

## Testing:

1. Git fetch and checkout this branch ` lh-api-tests ` in your API project directory
2. Run the ` python3 manage.py test tests -v 1 ` command in your terminal to run tests
3. Verify successful test result readout as follows:
``` 
Found 6 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
......
----------------------------------------------------------------------
Ran 6 tests in 0.040s

OK
Destroying test database for alias 'default'... 
```