### PR TITLE
Created Subscription View

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,9 @@
     "--django-settings-module=honeyrae.settings"
   ],
   "cSpell.words": [
-    "rareapi"
+    "postreaction",
+    "postreactions",
+    "rareapi",
+    "viewsets"
   ]
 }

--- a/rare/urls.py
+++ b/rare/urls.py
@@ -22,17 +22,17 @@ from rareapi.views import register_user, login_user, PostView, TagViewSet, PostR
 from django.conf.urls import include
 from rest_framework import routers
 from rareapi.views import CategoryViewSet
-from rareapi.views import ReactionViewSet, RareUserView
-
+from rareapi.views import ReactionViewSet, RareUserView, SubscriptionViewSet
 
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'categories', CategoryViewSet, 'category')
 router.register(r'posts', PostView, 'post')
 router.register(r'reactions', ReactionViewSet, 'reaction')
-router.register(r'tags', TagViewSet, 'tag' )
+router.register(r'tags', TagViewSet, 'tag')
 router.register(r'postreactions', PostReactionView, 'postreaction')
 router.register(r'rareusers', RareUserView, 'rareuser')
+router.register(r'subscriptions', SubscriptionViewSet, 'subscription')
 
 
 urlpatterns = [

--- a/rareapi/views/__init__.py
+++ b/rareapi/views/__init__.py
@@ -4,4 +4,5 @@ from .tags import TagViewSet
 from .post_view import PostView
 from .reactions import ReactionViewSet
 from .post_reaction_view import PostReactionView
-from .rare_user import RareUserView 
+from .rare_user import RareUserView
+from .subscription_view import SubscriptionViewSet

--- a/rareapi/views/subscription_view.py
+++ b/rareapi/views/subscription_view.py
@@ -1,0 +1,62 @@
+from rest_framework import viewsets, status
+from rest_framework import serializers
+from rest_framework.response import Response
+from rareapi.models import Subscription, RareUser
+from rareapi.views.rare_user import RareUserSerializer
+
+
+class SubscriptionSerializer(serializers.ModelSerializer):
+
+    author = RareUserSerializer(many=False)
+    follower = RareUserSerializer(many=False)
+
+    class Meta:
+        model = Subscription
+        fields = ['id', 'author', 'follower', 'created_on', 'ended_on']
+
+
+class SubscriptionViewSet(viewsets.ViewSet):
+
+    def list(self, request):
+        subscriptions = Subscription.objects.all()
+        serializer = SubscriptionSerializer(subscriptions, many=True)
+        return Response(serializer.data)
+
+    def retrieve(self, request, pk):
+        try:
+            subscription = Subscription.objects.get(pk=pk)
+            serializer = SubscriptionSerializer(
+                subscription, context={'request': request})
+            return Response(serializer.data)
+        except Subscription.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def create(self, request):
+        author_id = request.data.get('author')
+        follower_id = request.data.get('follower')
+
+        author = RareUser.objects.get(pk=author_id)
+        follower = RareUser.objects.get(pk=follower_id)
+
+        subscription = Subscription()
+        subscription.author = author
+        subscription.follower = follower
+        subscription.created_on = request.data.get('created_on')
+        subscription.ended_on = request.data.get('ended_on')
+        subscription.save()
+
+        try:
+            serializer = SubscriptionSerializer(subscription, many=False)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        except Exception as ex:
+            return Response(None, status=status.HTTP_404_NOT_FOUND)
+
+    def destroy(self, request, pk=None):
+        try:
+            subscription = Subscription.objects.get(pk=pk)
+            subscription.delete()
+
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        except Subscription.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## Subscription Viewset Overview

- Created URL pathway for subscriptions
- Created the model ```subscription_view.py``` including a retrieve, list, create, destroy
- Serializer has all fields and expanded on the author & follower field to have more fields pertaining to RareUser table

Expected JSON response body format
```
{
    "id": 1,
    "author": {
        "id": 1,
        "user": {
            "full_name": "Michelle Primiani",
            "email": "michelle@email.com",
            "user_profile_type": "author",
            "date_joined": "2023-11-20T15:47:38.557757Z"
        },
        "image_avatar": "https://example.com/user1.jpg"
    },
    "follower": {
        "id": 2,
        "user": {
            "full_name": "Spencer Norris",
            "email": "spencer@email.com",
            "user_profile_type": "author",
            "date_joined": "2023-11-20T15:48:41.444260Z"
        },
        "image_avatar": "https://example.com/user2.jpg"
    },
    "created_on": "2023-01-01",
    "ended_on": null
}
```


## How To Test

- pull down branch ```mp-subscription-viewset```
- make sure debugger is running
- do the following requests in Postman
- make GET request to ```http://localhost:8000/subscriptions``` ensure all subscriptions are listed (200 OK STATUS)
- make GET request to ```http://localhost:8000/subscriptions/1``` ensure id # 1 is listed (200 OK STATUS)
- make a CREATE request ```http://localhost:8000/subscriptions``` with ```
{
    "author": 4,
    "follower": 5
}``` as JSON RAW body and ensure that new object has been created (201 CREATED STATUS)
- Make note of the ID from CREATE request and make a DELETE request to ```http://localhost:8000/subscriptions/n``` and ensure object has been deleted (204 NO CONTENT)

## Working On Next 
- Creating tests for subscriptions 
- Client side 