### PR TITLE
Subscriptions on RareUser Serializer

### DIFF
--- a/rareapi/views/rare_user.py
+++ b/rareapi/views/rare_user.py
@@ -1,15 +1,23 @@
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
-from rareapi.models import RareUser
+from rareapi.models import RareUser, Subscription
 from django.contrib.auth.models import User
+
+
+class RareUserSubscriptionSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Subscription
+        fields = ['id', 'author_id', 'follower_id', 'created_on']
+
 
 class RareUserUserSerializer(serializers.ModelSerializer):
     full_name = serializers.SerializerMethodField()
 
     def get_full_name(self, obj):
         return f'{obj.first_name} {obj.last_name}'
-    
+
     user_profile_type = serializers.SerializerMethodField()
 
     def get_user_profile_type(self, obj):
@@ -21,31 +29,39 @@ class RareUserUserSerializer(serializers.ModelSerializer):
         model = User
         fields = ['full_name', 'email', 'user_profile_type', 'date_joined']
 
+
 class RareUserSerializer(serializers.ModelSerializer):
     user = RareUserUserSerializer(many=False)
     image_avatar = serializers.SerializerMethodField()
+    subscriptions_as_author = RareUserSubscriptionSerializer(
+        many=True, read_only=True)
+    subscriptions_as_follower = RareUserSubscriptionSerializer(
+        many=True, read_only=True)
 
     def get_image_avatar(self, obj):
         if obj.image_url:
             return obj.image_url
         return 'https://cdn1.iconfinder.com/data/icons/user-pictures/100/unknown-512.png'
-    
+
     class Meta:
         model = RareUser
-        fields = ['id', 'user', 'image_avatar']
+        fields = ['id', 'user', 'image_avatar',
+                  'subscriptions_as_author', 'subscriptions_as_follower']
 
 
 class RareUserView(ViewSet):
 
     def list(self, request):
         rare_users = RareUser.objects.all()
-        serializer = RareUserSerializer(rare_users, many=True, context={'request': request})
+        serializer = RareUserSerializer(
+            rare_users, many=True, context={'request': request})
         return Response(serializer.data)
-    
+
     def retrieve(self, request, pk):
         try:
             rare_user = RareUser.objects.get(pk=pk)
-            serializer = RareUserSerializer(rare_user, context={'request': request})
+            serializer = RareUserSerializer(
+                rare_user, context={'request': request})
             return Response(serializer.data)
         except RareUser.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/rareapi/views/rare_user.py
+++ b/rareapi/views/rare_user.py
@@ -34,9 +34,9 @@ class RareUserSerializer(serializers.ModelSerializer):
     user = RareUserUserSerializer(many=False)
     image_avatar = serializers.SerializerMethodField()
     subscriptions_as_author = RareUserSubscriptionSerializer(
-        many=True, read_only=True)
+        many=True)
     subscriptions_as_follower = RareUserSubscriptionSerializer(
-        many=True, read_only=True)
+        many=True)
 
     def get_image_avatar(self, obj):
         if obj.image_url:


### PR DESCRIPTION
## Subscriptions added to RareUser Serializer Overview

When a request is made to ```http://localhost:8000/rareusers``` the response body now has ```subscriptions_as_author``` and ```subscriptions_as_follower```. This is to ensure client side makes one fetch call in component when rendering subscription button.

## How To Test

- pull down branch ```mp-subscription-test```
- make sure debugger is running
- in Postman, make a GET request to ```http://localhost:8000/rareusers``` and ensure this is the example response body below with 200 OK status
```
    {
        "id": 1,
        "user": {
            "full_name": "Michelle Primiani",
            "email": "michelle@email.com",
            "user_profile_type": "author",
            "date_joined": "2023-11-20T15:47:38.557757Z"
        },
        "image_avatar": "https://example.com/user1.jpg",
        "subscriptions_as_author": [
            {
                "id": 1,
                "author_id": 1,
                "follower_id": 2,
                "created_on": "2023-01-01"
            }
        ],
        "subscriptions_as_follower": []
    },
```

- double check tests are running properly
- in terminal run command ```python3 manage.py test tests -v 1```
- and ensure this is the response (27 tests pass)
```
Found 27 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...........................
----------------------------------------------------------------------
Ran 27 tests in 0.420s

OK
Destroying test database for alias 'default'...
```