### PR TITLE
Added current_user_is_subscribed to RareUser View Serializer

### DIFF
--- a/rareapi/views/rare_user.py
+++ b/rareapi/views/rare_user.py
@@ -40,33 +40,17 @@ class RareUserSerializer(serializers.ModelSerializer):
         # Get the user id of the current user from the request
         current_user_id = self.context['request'].user.id
 
+        # Get all the subscriptions of the current RareUser where it is an author
         rare_user_subscriptions_as_author = obj.subscriptions_as_author.values()
 
+        # Loop through all subscriptions where RareUser is an author
         for subscription in rare_user_subscriptions_as_author:
             current_is_subscribed = False
+            # Conditional to see if current user is subscribed to RareUser and if it is still current
             if subscription['follower_id'] == current_user_id and subscription['ended_on'] is None:
                 return True
             
-
         return current_is_subscribed
-        # Filter through Subscriptions to find the current user's subscriptions
-        # current_user_subscriptions =  Subscription.objects.filter(follower_id=current_user_id)
-        
-        # Filter through current user's subscriptions to find if RareUser.id (obj.id) matches
-        # Subscription.author_id
-        # obj is the instance of RareUser that is currently passed through serializer
-        # rare_user_is_author_for_current_user_subscription = current_user_subscriptions.filter(author_id = obj.id)
-
-        # Filter through a user's subscription to see if ended_on field is NULL
-        # confirming that subscription is still valid/current
-        # current_user_is_currently_subscribed = rare_user_is_author_for_current_user_subscription.filter(ended_on__isnull=True)
-
-        # If current user is currently subscribed to current subscription,
-        # return True as the value of is_subscribed property
-        # if current_user_is_currently_subscribed.exists():
-        #     return True
-        # else:
-        #     return False
    
     def get_created_on(self, obj):
         return f'{obj.created_on.month}/{obj.created_on.day}/{obj.created_on.year}'

--- a/rareapi/views/rare_user.py
+++ b/rareapi/views/rare_user.py
@@ -2,7 +2,14 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
 from rareapi.models import RareUser, Subscription
+from rareapi.views.subscription_view import SubscriptionSerializer
 from django.contrib.auth.models import User
+
+# class RareUserSubscriptionSerializer(serializers.ModelSerializer):
+
+#     class Meta:
+#         model = Subscription
+#         fields = ['id', 'author_id', 'follower_id']
 
 class RareUserUserSerializer(serializers.ModelSerializer):
     full_name = serializers.SerializerMethodField()
@@ -27,29 +34,39 @@ class RareUserSerializer(serializers.ModelSerializer):
     image_avatar = serializers.SerializerMethodField()
     created_on = serializers.SerializerMethodField()
     current_user_is_subscribed = serializers.SerializerMethodField()
+    # subscriptions_as_followers = RareUserSubscriptionSerializer(many=True)
     
     def get_current_user_is_subscribed(self, obj):
         # Get the user id of the current user from the request
         current_user_id = self.context['request'].user.id
 
+        rare_user_subscriptions_as_author = obj.subscriptions_as_author.values()
+
+        for subscription in rare_user_subscriptions_as_author:
+            current_is_subscribed = False
+            if subscription['follower_id'] == current_user_id and subscription['ended_on'] is None:
+                return True
+            
+
+        return current_is_subscribed
         # Filter through Subscriptions to find the current user's subscriptions
-        current_user_subscriptions =  Subscription.objects.filter(follower_id=current_user_id)
+        # current_user_subscriptions =  Subscription.objects.filter(follower_id=current_user_id)
         
         # Filter through current user's subscriptions to find if RareUser.id (obj.id) matches
         # Subscription.author_id
         # obj is the instance of RareUser that is currently passed through serializer
-        rare_user_is_author_for_current_user_subscription = current_user_subscriptions.filter(author_id = obj.id)
+        # rare_user_is_author_for_current_user_subscription = current_user_subscriptions.filter(author_id = obj.id)
 
         # Filter through a user's subscription to see if ended_on field is NULL
         # confirming that subscription is still valid/current
-        current_user_is_currently_subscribed = rare_user_is_author_for_current_user_subscription.filter(ended_on__isnull=True)
+        # current_user_is_currently_subscribed = rare_user_is_author_for_current_user_subscription.filter(ended_on__isnull=True)
 
         # If current user is currently subscribed to current subscription,
         # return True as the value of is_subscribed property
-        if current_user_is_currently_subscribed.exists():
-            return True
-        else:
-            return False
+        # if current_user_is_currently_subscribed.exists():
+        #     return True
+        # else:
+        #     return False
    
     def get_created_on(self, obj):
         return f'{obj.created_on.month}/{obj.created_on.day}/{obj.created_on.year}'

--- a/rareapi/views/rare_user.py
+++ b/rareapi/views/rare_user.py
@@ -38,6 +38,10 @@ class RareUserSerializer(serializers.ModelSerializer):
     subscriptions_as_follower = RareUserSubscriptionSerializer(
         many=True)
     created_on = serializers.SerializerMethodField()
+    # is_subscribed = serializers.SerializerMethodField()
+
+    # def get_is_subscribed(self, obj):
+    #     matching_subscriptions = Subscription.objects.filter(obj.follower_id)
 
     def get_created_on(self, obj):
         return f'{obj.created_on.month}/{obj.created_on.day}/{obj.created_on.year}'

--- a/rareapi/views/subscription_view.py
+++ b/rareapi/views/subscription_view.py
@@ -10,28 +10,9 @@ class SubscriptionSerializer(serializers.ModelSerializer):
     author = RareUserSerializer(many=False)
     follower = RareUserSerializer(many=False)
 
-    is_subscribed = serializers.SerializerMethodField()
-
-    def get_is_subscribed(self, obj):
-        # Get the user id of the current user from the request
-        current_user_id = self.context['request'].user.id
-
-        # Filter through Subscriptions Objects to find the current user's subscriptions
-        current_users_subscriptions =  Subscription.objects.filter(follower_id=current_user_id)
-        
-        # Filter through current user's subscriptions to find if user is subscribed to the
-        # author of the current Subscription Instance/Object(obj) being serialized via author_id property 
-        user_is_subscribed = current_users_subscriptions.filter(author_id=obj.author_id)
-        
-        #If current user is subscribed to said author, return True as the value of is_subscribed property
-        if user_is_subscribed.exists():
-            return True
-        else:
-            return False
-
     class Meta:
         model = Subscription
-        fields = ['id', 'author', 'follower', 'created_on', 'ended_on', 'is_subscribed']
+        fields = ['id', 'author', 'follower', 'created_on', 'ended_on']
 
 
 class SubscriptionViewSet(viewsets.ViewSet):

--- a/rareapi/views/subscription_view.py
+++ b/rareapi/views/subscription_view.py
@@ -2,13 +2,9 @@ from rest_framework import viewsets, status
 from rest_framework import serializers
 from rest_framework.response import Response
 from rareapi.models import Subscription, RareUser
-from rareapi.views.rare_user import RareUserSerializer
 
 
 class SubscriptionSerializer(serializers.ModelSerializer):
-
-    author = RareUserSerializer(many=False)
-    follower = RareUserSerializer(many=False)
 
     class Meta:
         model = Subscription

--- a/rareapi/views/subscription_view.py
+++ b/rareapi/views/subscription_view.py
@@ -19,10 +19,11 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         # Filter through Subscriptions Objects to find the current user's subscriptions
         current_users_subscriptions =  Subscription.objects.filter(follower_id=current_user_id)
         
-        # Filter through current user's subscriptions to find if user is subscribed to 
-        # author via author_id property of current Subscription Object(obj) being serialized
+        # Filter through current user's subscriptions to find if user is subscribed to the
+        # author of the current Subscription Instance/Object(obj) being serialized via author_id property 
         user_is_subscribed = current_users_subscriptions.filter(author_id=obj.author_id)
         
+        #If current user is subscribed to said author, return True as the value of is_subscribed property
         if user_is_subscribed.exists():
             return True
         else:


### PR DESCRIPTION
### To Test

- pull down `ndw-view-profile`
- start in debugger mode
- Start client side via `npm-start`

- Log into Rare as an authenticated user
- Note authenticated user's id (can check database or LocalStorage)
- navigate to AllUsers view
- Open DevTools and navigate to Components Tab
- Go into `rareapi_subscriptions` in API database and see if current user has a subscription (their primary key id will be the same as a follower_id field value)
- If they do not have a subscription then there should be no object in State(RareUsers array) where the key `current_user_is_subscribed` value is `True`
- If current user does have a subscription, then `current_user_is_subscribed` should be True for the RareUser object(Author) whose `id = author_id` of the subscription (can use database to see author's RareUser id)
- Click the `Subscribe` button next to a RareUser and check to make sure that State has changed so that `current_user_is_subscribed` is true for the correct RareUser object (author)
- Go into fixtures in the API and change `ended_on` from null to a valid Date String (e.g. "2023-02-02") for a current user's subscription, or add subscription for current user and make the  `ended-on` field value a valid Date string.
- in terminal for API, load new fixtures `python3 manage.py loaddata subscriptions` 
- Make sure in Dev Tools of app that `current_user_is_
subscribed` is now False due to `ended-on` value changing from null

- Log in as another user and check to make sure that all functionalities work as directed